### PR TITLE
Debounce deliveries table fetch

### DIFF
--- a/components/deliveries-table.tsx
+++ b/components/deliveries-table.tsx
@@ -188,7 +188,11 @@ export function DeliveriesTable({
 
   // Fetch the current group of pages when filters, search, sort, or groupIndex change
   useEffect(() => {
-    fetchGroupData();
+    const timeoutId = setTimeout(() => {
+      fetchGroupData();
+    }, 300);
+
+    return () => clearTimeout(timeoutId);
   }, [
     statusFilter,
     typeFilter,


### PR DESCRIPTION
## Summary
- debounce filter-based requests in deliveries table to avoid spamming API on quick changes
- keep 30s polling for background refresh

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_68bae2dd2750832389bee5fff11038d3