### PR TITLE
feat: cache and share dashboard order data

### DIFF
--- a/components/dashboard-stats.tsx
+++ b/components/dashboard-stats.tsx
@@ -5,6 +5,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Skeleton } from "@/components/ui/skeleton"
 import { Package, Truck, CheckCircle, Clock, TrendingUp, AlertTriangle, Timer, Users } from "lucide-react"
 import type { Mission } from "@/lib/types"
+import { useOrders } from "@/lib/useOrders"
 
 interface AnalyticsData {
   todayCompletions: number
@@ -84,28 +85,7 @@ function StatsSkeleton() {
 }
 
 export const DashboardStats = React.memo(function DashboardStats() {
-  const [analytics, setAnalytics] = useState<AnalyticsData | null>(null)
-  const [loading, setLoading] = useState(true)
-
-  const fetchAnalytics = useMemo(() => async () => {
-    try {
-      const response = await fetch("/api/orders")
-      if (response.ok) {
-        const data = await response.json()
-        const missions: Mission[] = Array.isArray(data) ? data : data.data || []
-        const analyticsData = calculateAnalytics(missions)
-        setAnalytics(analyticsData)
-      }
-    } catch (error) {
-      console.error("Error fetching analytics:", error)
-    } finally {
-      setLoading(false)
-    }
-  }, [])
-
-  useEffect(() => {
-    fetchAnalytics()
-  }, [fetchAnalytics])
+  const { orders, loading } = useOrders()
 
   const calculateAnalytics = useMemo(() => (missions: Mission[]): AnalyticsData => {
     const today = new Date()
@@ -179,12 +159,10 @@ export const DashboardStats = React.memo(function DashboardStats() {
     }
   }, [])
 
+  const analytics = useMemo(() => calculateAnalytics(orders), [orders, calculateAnalytics])
+
   if (loading) {
     return <StatsSkeleton />
-  }
-
-  if (!analytics) {
-    return <div>שגיאה בטעינת הנתונים</div>
   }
 
   const stats = [

--- a/lib/useOrders.ts
+++ b/lib/useOrders.ts
@@ -1,0 +1,72 @@
+"use client"
+
+import { useState, useEffect, useCallback } from "react"
+import type { Mission } from "@/lib/types"
+
+let ordersCache: Mission[] | null = null
+let fetching: Promise<Mission[]> | null = null
+const listeners: Array<(orders: Mission[]) => void> = []
+
+async function fetchOrders(): Promise<Mission[]> {
+  const res = await fetch("/api/orders")
+  if (!res.ok) throw new Error("Failed to fetch orders")
+  const result = await res.json()
+  return Array.isArray(result) ? result : result.data || []
+}
+
+function notify(orders: Mission[]) {
+  for (const listener of listeners) {
+    listener(orders)
+  }
+}
+
+function subscribe(listener: (orders: Mission[]) => void) {
+  listeners.push(listener)
+  return () => {
+    const index = listeners.indexOf(listener)
+    if (index > -1) listeners.splice(index, 1)
+  }
+}
+
+function setCache(orders: Mission[]) {
+  ordersCache = orders
+  notify(orders)
+}
+
+export function useOrders(options?: { refreshInterval?: number }) {
+  const [orders, setOrders] = useState<Mission[]>(ordersCache || [])
+  const [loading, setLoading] = useState(ordersCache === null)
+
+  const refresh = useCallback(async () => {
+    setLoading(true)
+    try {
+      fetching = fetchOrders()
+      const data = await fetching
+      setCache(data)
+    } finally {
+      setLoading(false)
+      fetching = null
+    }
+  }, [])
+
+  useEffect(() => {
+    const unsubscribe = subscribe(setOrders)
+    if (ordersCache === null) {
+      if (!fetching) {
+        refresh()
+      } else {
+        fetching.then(() => {})
+      }
+    }
+    return unsubscribe
+  }, [refresh])
+
+  useEffect(() => {
+    if (!options?.refreshInterval) return
+    const id = setInterval(refresh, options.refreshInterval)
+    return () => clearInterval(id)
+  }, [options?.refreshInterval, refresh])
+
+  return { orders, loading, refresh }
+}
+


### PR DESCRIPTION
## Summary
- add `useOrders` hook to fetch `/api/orders` once, cache results, and support refresh
- refactor dashboard stats and deliveries table to consume shared order data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: requires interactive ESLint setup)*

------
https://chatgpt.com/codex/tasks/task_e_68bae2daf9ec832396a43362328618ff